### PR TITLE
Fix offset text labelcolor rcparam

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1220,7 +1220,7 @@ class Axis(martist.Artist):
         if v0 == v1:
             _api.warn_external(
                 f"Attempting to set identical low and high {name}lims "
-                f"makes transformation singular; automatically expanding.")
+                "makes transformation singular; automatically expanding.")
         reverse = bool(v0 > v1)  # explicit cast needed for python3.8+np.bool_.
         v0, v1 = self.get_major_locator().nonsingular(v0, v1)
         v0, v1 = self.limit_range_for_scale(v0, v1)
@@ -2249,13 +2249,16 @@ class XAxis(Axis):
         )
         self.label_position = 'bottom'
 
+        x_offset_color = (mpl.rcParams['xtick.color']
+                          if mpl.rcParams['xtick.labelcolor'] == 'inherit'
+                          else mpl.rcParams['xtick.labelcolor'])
         self.offsetText.set(
             x=1, y=0,
             verticalalignment='top', horizontalalignment='right',
             transform=mtransforms.blended_transform_factory(
                 self.axes.transAxes, mtransforms.IdentityTransform()),
             fontsize=mpl.rcParams['xtick.labelsize'],
-            color=mpl.rcParams['xtick.color'],
+            color=x_offset_color,
         )
         self.offset_text_position = 'bottom'
 
@@ -2509,13 +2512,16 @@ class YAxis(Axis):
         )
         self.label_position = 'left'
         # x in axes coords, y in display coords(!).
+        y_offset_color = (mpl.rcParams['ytick.color']
+                          if mpl.rcParams['ytick.labelcolor'] == 'inherit'
+                          else mpl.rcParams['ytick.labelcolor'])
         self.offsetText.set(
             x=0, y=0.5,
             verticalalignment='baseline', horizontalalignment='left',
             transform=mtransforms.blended_transform_factory(
                 self.axes.transAxes, mtransforms.IdentityTransform()),
             fontsize=mpl.rcParams['ytick.labelsize'],
-            color=mpl.rcParams['ytick.color'],
+            color=y_offset_color,
         )
         self.offset_text_position = 'left'
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6801,6 +6801,14 @@ def test_offset_label_color():
     assert ax.yaxis.get_offset_text().get_color() == 'red'
 
 
+def test_offset_label_color_rcparams():
+    with mpl.rc_context({'ytick.labelcolor': 'red'}):
+        fig, ax = plt.subplots()
+        ax.plot([1.01e9, 1.02e9, 1.03e9])
+        fig.canvas.draw()
+        assert ax.yaxis.get_offset_text().get_color() == 'red'
+
+
 def test_offset_text_visible():
     fig, ax = plt.subplots()
     ax.plot([1.01e9, 1.02e9, 1.03e9])


### PR DESCRIPTION
## Summary
- use xtick.labelcolor/ytick.labelcolor for offset text
- test offset text color from rcparams

## Testing
- `pre-commit run --files lib/matplotlib/axis.py lib/matplotlib/tests/test_axes.py`
- `pytest lib/matplotlib/tests/test_axes.py::test_offset_label_color_rcparams -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68516a9afb10832a94217b7419e22e70